### PR TITLE
Added sliding transition between debug/run button.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,4 +5,4 @@ Additional thanks to the following people for their contributions:
 [generate file descriptor table diagrams](https://reberhardt.com/blog/2019/12/12/generating-diagrams-for-teaching-multiprocessing.html)
 * Blanca Villanueva, for developing a prototype of the UI that allows users to set breakpoints
 * Cathy Zhang
-* Noah Geller
+* Noah Geller, for various UI tweaks

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,3 +4,4 @@ Additional thanks to the following people for their contributions:
 * Isaiah Bush, for developing the frontend code to
 [generate file descriptor table diagrams](https://reberhardt.com/blog/2019/12/12/generating-diagrams-for-teaching-multiprocessing.html)
 * Blanca Villanueva, for developing a prototype of the UI that allows users to set breakpoints
+* Noah Geller, for various UI tweaks

--- a/src/client/components/Topbar.tsx
+++ b/src/client/components/Topbar.tsx
@@ -91,19 +91,20 @@ class Topbar extends React.PureComponent<TopbarProps> {
                     tabIndex={0}
                 >
                     <div className="main-text">
-                        {this.props.debug
-                            ? (
-                                <div className="icon run-icon debug-icon">
-                                    <span className="outline"><i className="fas fa-bug" /></span>
-                                    <span className="filled"><i className="fas fa-bug" /></span>
-                                </div>
-                            ) : (
-                                <div className="icon run-icon">
-                                    <span className="outline">&#9655;</span>
-                                    <span className="filled">&#9654;</span>
-                                </div>
-                            )}
-                        { this.props.debug ? 'Debug' : 'Run' }
+                        <div className={this.props.debug ? 'active' : 'inactive'}>
+                            <div className="icon run-icon debug-icon">
+                                <span className="outline"><i className="fas fa-bug" /></span>
+                                <span className="filled"><i className="fas fa-bug" /></span>
+                            </div>
+                            Debug
+                        </div>
+                        <div className={this.props.debug ? 'inactive' : 'active'}>
+                            <div className="icon run-icon">
+                                <span className="outline">&#9655;</span>
+                                <span className="filled">&#9654;</span>
+                            </div>
+                            Run
+                        </div>
                     </div>
                     <div className="shortcut">shift+enter</div>
                 </div>

--- a/src/client/styles/_topbar.scss
+++ b/src/client/styles/_topbar.scss
@@ -67,6 +67,24 @@
     margin-right: 10px;
 }
 
+#run-btn .main-text {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#run-btn .main-text .inactive {
+    position: absolute;
+    display: hidden;
+    transform: translateY(500%);
+    transition: transform 0.4s ease-out;
+}
+
+#run-btn .main-text .active {
+    transform: none;
+    transition: transform 0.4s ease-out;
+}
+
 #run-btn .run-icon .filled {
     position: absolute;
     top: 0;

--- a/src/client/styles/_topbar.scss
+++ b/src/client/styles/_topbar.scss
@@ -71,18 +71,19 @@
     display: flex;
     justify-content: center;
     align-items: center;
-}
 
-#run-btn .main-text .inactive {
-    position: absolute;
-    display: hidden;
-    transform: translateY(500%);
-    transition: transform 0.4s ease-out;
-}
+    .inactive {
+        position: absolute;
+        transform: rotateX(180deg);
+        transition: transform 0.4s ease-out;
+        backface-visibility: hidden;
+    }
 
-#run-btn .main-text .active {
-    transform: none;
-    transition: transform 0.4s ease-out;
+    .active {
+        transform: none;
+        transition: transform 0.4s ease-out;
+        backface-visibility: hidden;
+    }
 }
 
 #run-btn .run-icon .filled {


### PR DESCRIPTION
I gave a sliding transition to the debug/run button as it transitions between debug and run mode (issue #20). This required me to:
- Turn the button container into a CSS flex box for alignment purposes
- Add active/inactive classes to each button according to whether we're in debug or run mode
- Add a translateY transition for the inactive button to slide it out of view
The transition can easily be changed to something else down the line without breaking anything.