### PR TITLE
Don't add CAP_SYS_PTRACE to containers

### DIFF
--- a/src/server/container.ts
+++ b/src/server/container.ts
@@ -197,8 +197,10 @@ export default class Container {
                 throw new SystemConfigurationError('ptrace is not safe to use on linux versions '
                     + 'older than 4.8, as it can be used to bypass seccomp.');
             }
-            // Grant ptrace capability for gdb
-            runArgs.push('--cap-add=SYS_PTRACE');
+            // Docker itself runs the above check too, and grants the ptrace syscall in its seccomp
+            // profile (without granting the dangerous CAP_SYS_PTRACE) on kernel versions past 4.8,
+            // meaning we need not do anything to give gdb the perms it needs
+
             // Tell run.py to run in debug mode
             runArgs.push('-e', 'CPLAYGROUND_DEBUG=1');
         }


### PR DESCRIPTION
Docker, on recent kernel versions, whitelists the syscall without necessitating the add-dangerous-permission flag. Courtesy of [this blog post](https://jvns.ca/blog/2020/04/29/why-strace-doesnt-work-in-docker/).

Addresses #31. While this is the most important change on that front, I'm leaving that issue per discussion with @reberhardt7 for discussion the possibility that we can add a syscall filter to the user code to prevent the ptrace syscall entirely (as opposed to just the high-privilege 'ptrace anything' capability). It's a lower-priority issue now.