### PR TITLE
Add kernel module parameter for cplayground file owner

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -102,7 +102,7 @@ Vagrant.configure("2") do |config|
     fi
     (
       cd /cplayground/src/server/kernel-mod
-      sudo insmod cplayground.ko
+      sudo insmod cplayground.ko "file_uid=$(id -u vagrant)" "file_gid=$(id -g vagrant)"
     )
 
     # Virtualbox shared folders don't support unix domain sockets (which we use

--- a/src/server/kernel-mod/cplayground.c
+++ b/src/server/kernel-mod/cplayground.c
@@ -18,6 +18,14 @@ MODULE_AUTHOR("Ryan Eberhardt");
 MODULE_DESCRIPTION("Cplayground debugging module");
 MODULE_VERSION("0.01");
 
+static uid_t file_uid = 0;
+static gid_t file_gid = 0;
+
+module_param(file_uid, uint, 0000);
+MODULE_PARM_DESC(file_uid, "The UID to own the cplayground data file");
+module_param(file_gid, uint, 0000);
+MODULE_PARM_DESC(file_gid, "The GID to own the cplayground data file");
+
 static struct proc_dir_entry *cplayground_dirent = NULL;
 
 // Most of this hashing code is stolen from
@@ -301,9 +309,8 @@ static int __init lkm_example_init(void) {
     if (cplayground_dirent == NULL) {
         return -ENOMEM;
     }
-    // TODO: Don't hardcode uid 1000
-    kuid_t uid = { .val = 1000 };
-    kgid_t gid = { .val = 1000 };
+    kuid_t uid = { .val = file_uid };
+    kgid_t gid = { .val = file_gid };
     proc_set_user(cplayground_dirent, uid, gid);
     return 0;
 }

--- a/src/server/kernel-mod/cplayground.c
+++ b/src/server/kernel-mod/cplayground.c
@@ -1,5 +1,6 @@
 #include <linux/init.h>
 #include <linux/module.h>
+#include <linux/moduleparam.h>
 #include <linux/kernel.h>
 #include <linux/sched.h>            // for_each_process, pr_info
 #include <linux/sched/signal.h>     // for_each_process, pr_info


### PR DESCRIPTION
Fixes #28. Instead of hardcoding UID 1000 and GID 1000 as the owner of the cplayground procfs file, default to being `root:root` owned, but expose module parameters to allow the sysadmin to set the user. In the Vagrantfile, pull the UID and GID of our vagrant user and set that as the file owner.

I elected to change the default to root ownership because that felt more appropriate for a general default: process introspection should be secure by default, and assuming UID 1000 at the module level feels hacky. UID 0, by contrast, is meaningful on every Linux system. Changing the owner UID is as simple as a module reload, and could probably be exposed by a sysfs parameter without too much trouble if we are so inclined.