### PR TITLE
Add wrapper program to apply seccomp to user code

### DIFF
--- a/src/server/container.ts
+++ b/src/server/container.ts
@@ -433,6 +433,9 @@ export default class Container {
         await this.gdb.enableAsync();
         await this.gdb.attachOnFork();
 
+        // Setup sandboxing
+        await this.gdb.set('exec-wrapper', '/sandbox');
+
         // Set and save initial breakpoints
         const initialBreakpointObjs = await Promise.all(this.initialBreakpoints.map(
             (lineno) => this.gdb.addBreak(this.codeContainerPath, lineno),

--- a/src/server/docker-image/Dockerfile
+++ b/src/server/docker-image/Dockerfile
@@ -1,3 +1,12 @@
+# this is a multi-stage docker build
+# start by building the sandbox wrapper application written in C
+# use a gcc image separate from the main image so we don't leave sandbox build clutter in the target
+FROM gcc:10.2.0 AS sandbox-build
+COPY sandbox /usr/src/cplayground_sandbox
+WORKDIR /usr/src/cplayground_sandbox
+RUN gcc -o /usr/bin/cplayground_sandbox main.c
+
+# build the target image for running the user application
 FROM ubuntu:latest
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y apt-utils build-essential bc unzip nsnake python3 gdb
@@ -5,11 +14,13 @@ RUN apt-get update && \
 RUN groupadd -g 999 cplayground \
     && useradd -r -u 999 -g cplayground -d /cplayground cplayground
 
-ADD run.py /run.py
+COPY run.py /run.py
+COPY --from=sandbox-build /usr/bin/cplayground_sandbox /sandbox
 RUN mkdir -p /cplayground \
     && chmod 777 /cplayground \
     && chown -R cplayground:cplayground /cplayground \
-    && chmod +x run.py
+    && chmod +x run.py \
+    && chmod +x sandbox
 
 USER cplayground
 WORKDIR /cplayground

--- a/src/server/docker-image/run.py
+++ b/src/server/docker-image/run.py
@@ -74,12 +74,14 @@ def run():
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as gdbsock:
             gdbsock.connect('/gdb.sock')
             sockfile = gdbsock.makefile('b', 0)
+            # the node server is responsible for ensuring gdb sandboxes its child
             args = ['gdb', '--tty=/dev/pts/0', '-i=mi', '--args', '/cplayground/cplayground'] + sys.argv[1:]
             user_proc = subprocess.Popen(args, stdin=sockfile, stdout=sockfile, stderr=sockfile,
                                          preexec_fn=become_fg_process)
             user_proc.wait()
     else:
-        user_proc = subprocess.run(['/cplayground/cplayground'] + sys.argv[1:],
+        # this script will ensure sandboxing
+        user_proc = subprocess.run(['/sandbox', '/cplayground/cplayground'] + sys.argv[1:],
                                    preexec_fn=become_fg_process)
     return (user_proc.returncode, time.time() - user_start_time)
 

--- a/src/server/docker-image/sandbox/main.c
+++ b/src/server/docker-image/sandbox/main.c
@@ -1,0 +1,64 @@
+#include <errno.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <linux/audit.h>
+
+#include <sys/types.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/socket.h>
+
+// based on https://eigenstate.org/notes/seccomp.html
+// relevant reading: https://lwn.net/Articles/656307/
+// note since the cplayground is open source and the user can easily
+// submit arbitrary programs, arguments about probing defenses are
+// not particularly meaningful
+// we use RET_ERRNO with ERFKILL - relatively arbitrary, and distinct
+// from most errors we would expect to see in cplayground
+#define SECCOMP_DENY(syscall) \
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_##syscall, 0, 1), \
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (ERFKILL & SECCOMP_RET_DATA))
+
+struct sock_filter filter[] = {
+    // validate arch, kill on mismatch
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, arch)),
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, AUDIT_ARCH_X86_64, 1, 0),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL),
+
+    // load syscall
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+
+    // list of blocked syscalls
+    SECCOMP_DENY(ptrace),
+
+    // if we don't match above, permit
+    // (docker and friends should stack on top of this)
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+};
+
+struct sock_fprog filterprog = {
+    .len = sizeof(filter)/sizeof(filter[0]),
+    .filter = filter
+};
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) exit(99);
+
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
+        exit(100);
+    }
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &filterprog) == -1) {
+        exit(100);
+    }
+
+    // the argv array is guaranteed to be null-terminated
+    // (https://stackoverflow.com/a/11020198)
+    execvp(argv[1], &argv[1]);
+
+    return 101;
+}


### PR DESCRIPTION
Fixes #41 by creating a "sandbox" executable which is deployed to the Docker image for running user code, and using it as `exec-wrapper` in GDB (or calling it directly as a wrapper when not debugging).

Currently it bans syscalls (only `ptrace` at the moment) by returning `ERFKILL` - I'm definitely open to alternatives here (`EPERM` comes to mind); I primarily picked `ERFKILL` so it's obviously weird when debugging the sandbox feature as opposed to ambiguous with a potentially "real" `EPERM`. (Alternatively we can just kill the child.)

Modifies the Dockerfile to use a multi-stage build: uses the `gcc:10.2.0` image to compile the sandbox program, then takes the compiled executable and copies it into the final cplayground Docker image. This lets us avoid installing any of the compilation garbage in the target image, although since we're installing build-essential anyway this may be less relevant. However, from what I can tell, this is the "right" way to make a Docker image for a C program. If we want to change the CFLAGS or whatnot used for the build of the sandbox, that will entail a Dockerfile tweak.

The sandbox program itself is a fairly straightforward seccomp BPF program which blocklists ptrace and allows all other syscalls. Seccomp policies can be stacked, so we won't be overriding Docker's policy or anything. I haven't thoroughly examined this for security, but I imagine as long as the user code cannot coerce any of its parent processes to run code not affected by this policy, we should be fine. If we knew more about user programs, it might make more sense to only list allowed calls and block the rest, but considering we accept essentially arbitrary user programs, this is probably out of scope for this PR. If the sandbox program fails to apply its policy and exec the child, it returns status 100 +/- 1.

My biggest gripe at the moment is probably that the responsibility for ensuring the sandbox actually gets installed is split between `run.py` and `container.ts`. I'm also not 100% happy with the ERFKILL return status, but I'm not sure what the right thing to do there is. Opening this PR for discussion and review.